### PR TITLE
Fix compile error: "expr: syntax error" in some Linux distros

### DIFF
--- a/efi/Makefile
+++ b/efi/Makefile
@@ -15,7 +15,7 @@ CCLDFLAGS	?= -nostdlib -Wl,--warn-common \
 	-Wl,-shared -Wl,-Bsymbolic -L$(LIBDIR) -L$(GNUEFIDIR) \
 	-Wl,--build-id=sha1 -Wl,--hash-style=sysv \
 	$(GNUEFIDIR)/crt0-efi-$(ARCH).o
-OBJCOPY_GTE224 = $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^.* //g' | cut -f1-2 -d.` \>= 2.24)
+OBJCOPY_GTE224 = $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^[^0-9]*//g' | cut -f1-2 -d.` \>= 2.24)
 
 FWUP = fwupdate
 


### PR DESCRIPTION
The "expr" command in efi/Makefile can cause build failed in some
Linux distros which have "objcopy --version" output like this

"GNU objcopy version 2.23.52.0.1-55.el7 20130226"

Signed-off-by: Huy Duong <quochuybk2010@gmail.com>